### PR TITLE
Change Dockerfile image and Fix/Add documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official OpenJDK image as the base image
-FROM openjdk:17-alpine as build
+FROM eclipse-temurin:17 as build
 
 # Set the working directory inside the container
 WORKDIR /app
@@ -17,7 +17,7 @@ COPY src src
 RUN ./gradlew build -x test
 
 # Start a new build stage
-FROM openjdk:17-alpine
+FROM eclipse-temurin:17
 
 # Set the working directory in this new stage
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@ Before you begin, ensure you have met the following requirements:
 
 - Docker is installed on your machine. Docker will handle the Java and Gradle dependencies for you, so there's no need to install them separately. If you don't have Docker installed, please follow the installation guide for [Docker](https://docs.docker.com/get-docker/).
 
+- **Windows Users** make sure you run the following command to set the line endings to match the *nix style to prevent issues with the Docker build:
+
+```bash
+git config --global core.autocrlf input
+```
+
 ## Running The Application
 
-1. **Clone The Repository** Open  a terminal and run the following command to clone the source repository:
+1. **Clone The Repository** Open a terminal and run the following command to clone the source repository:
 
 ```bash
 git clone https://github.com/LittleTechBookClub/swarm-rest-api.git
@@ -24,12 +30,12 @@ cd swarm-rest-api
 
 2. **Start the Application with Docker Compose** Run the following command to build and start the application along with any necessary services:
 ```bash
-docker-compose up
+docker compose up
 ```
 
 **Note for Linux users:** Depending on your Docker setup, you might need to prepend `sudo` to the above command:
 ```bash
-sudo docker-compose up
+sudo docker compose up
 ```
 
 3. **Accessing The Application*** You should be able to curl or check this url in browser: http://localhost:8080
@@ -39,7 +45,7 @@ and see "Hello Swarm!"
 
 To stop and remove the containers, use the following command:
 ```bash
-docker-compose down
+docker compose down
 ```
 
 **Linux Users** If you used `sudo` to start the application, make sure to use it here as well.


### PR DESCRIPTION
To run: 
Install Docker
Run `docker compose up`

- Corrected documentation to remove extra space
- Corrected the Dockerfile and changed image to eclipse-temurin:17 in order to support Mac users with M1 chip. This changed the size of the image from 345MB to 427MB. We could investigate how to make image leaner.
- Introduced new documentation for Windows users to address this [issue](https://stackoverflow.com/questions/70844518/cant-run-gradle-wrapper-with-docker-build)

Fixes #4 