### PR TITLE
Fix Windows Docker build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ COPY gradle gradle
 COPY build.gradle .
 COPY settings.gradle .
 
+# Ensure the gradlew script uses Unix line endings and is executable
+RUN apt-get update && apt-get install -y dos2unix && dos2unix gradlew
+RUN chmod +x gradlew
+
 # Copy the source code into the container
 COPY src src
 


### PR DESCRIPTION
Fix Docker build issues by ensuring Unix line endings and executable permission for gradlew

- Add dos2unix installation to Dockerfile to convert line endings of gradlew to Unix format
- Add chmod command to make gradlew executable
- Ensure build process runs smoothly by preventing line ending-related errors
- Allow Windows users who haven't configured Git to handle line endings to build the Docker image successfully
